### PR TITLE
Fixed issue with data missing from change event

### DIFF
--- a/elements/options-list.html
+++ b/elements/options-list.html
@@ -65,7 +65,7 @@
                    selected-values={{selectedValues}}>
       <template is="dom-repeat" items="[[shownOptions]]">
         <paper-icon-item
-            item$=[[item]]
+            item=[[item]]
             internal-id$="[[getValue(item)]]"
             on-click="_itemSelected"
             class$="[[item.cssClass]] [[_getSelectedClass(item)]]"


### PR DESCRIPTION
when the `on-iron-select` event is being fired, the event payload is missing the `event.detail.item.item` property described in the documentation 